### PR TITLE
Add syntax checking and ChefSpec framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+/cookbooks
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml
+
+.chef

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+-f documentation

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,16 @@
+Encoding:
+  Enabled: False
+LineLength:
+  Max: 600
+Documentation:
+  Enabled: False
+HashSyntax:
+  Enabled: False
+SingleSpaceBeforeFirstArg:
+  Enabled: false
+AsciiComments:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Max: 10
+Metrics/MethodLength:
+  Max: 20

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+#
+# Copyright © 2014-2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.4
+cache: bundler
+sudo: false
+bundler_args: --jobs 7 --without docs integration
+script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+
+gem 'berkshelf', '~> 3.0'
+gem 'foodcritic', '~> 3.0'
+
+gem 'chefspec', '~> 4.0'
+gem 'rspec', '~> 3.0'
+
+gem 'chef', '< 12.0' if RUBY_VERSION.to_f < 2.0
+
+gem 'rubocop'
+gem 'rubocop-checkstyle_formatter', require: false
+gem 'rainbow', '<= 1.99.1'
+
+group :integration do
+  gem 'test-kitchen'
+  gem 'kitchen-vagrant'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,48 @@
+#!/usr/bin/env rake
+
+require 'bundler/setup'
+
+# chefspec task against spec/*_spec.rb
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:chefspec)
+
+# foodcritic rake task
+desc 'Foodcritic linter'
+task :foodcritic do
+  sh 'foodcritic -f correctness .'
+end
+
+# rubocop rake task
+desc 'Ruby style guide linter'
+task :rubocop do
+  sh 'rubocop -D'
+end
+
+# creates metadata.json
+desc 'Create metadata.json from metadata.rb'
+task :metadata do
+  sh 'knife cookbook metadata from file metadata.rb'
+end
+
+# share cookbook to Chef community site
+desc 'Share cookbook to community site'
+task :share do
+  sh 'knife cookbook site share ambari other'
+end
+
+# test-kitchen
+begin
+  require 'kitchen/rake_tasks'
+  desc 'Run Test Kitchen integration tests'
+  task :integration do
+    Kitchen.logger = Kitchen.default_file_logger
+    Kitchen::Config.new.instances.each do |instance|
+      instance.test(:always)
+    end
+  end
+rescue LoadError
+  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+end
+
+# default tasks are quick, commit tests
+task :default => %w(foodcritic rubocop chefspec)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,23 +3,23 @@
 # Attributes:: default
 #
 
-default['ambari']['server_fqdn'] = "localhost"
+default['ambari']['server_fqdn'] = 'localhost'
 
 # Set default version to Ambari 2.0
-default['ambari']['version'] = "2.0"
+default['ambari']['version'] = '2.0'
 
 case node['ambari']['version']
-when "1.7"
-  default['ambari']['rhel_5_repo'] = "http://public-repo-1.hortonworks.com/ambari/centos5/1.x/updates/1.7.0/ambari.repo"
-  default['ambari']['rhel_6_repo'] = "http://public-repo-1.hortonworks.com/ambari/centos6/1.x/updates/1.7.0/ambari.repo"
-  default['ambari']['suse_11_repo'] = "http://public-repo-1.hortonworks.com/ambari/suse11/1.x/updates/1.7.0/ambari.repo"
-  default['ambari']['ubuntu_12_repo'] = "http://public-repo-1.hortonworks.com/ambari/ubuntu12/1.x/updates/1.7.0"
-when "2.0", "2" 
-  default['ambari']['rhel_5_repo'] = "http://public-repo-1.hortonworks.com/ambari/centos5/2.x/updates/2.0.1/ambari.repo"
-  default['ambari']['rhel_6_repo'] = "http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.0.1/ambari.repo"
-  default['ambari']['suse_11_repo'] = "http://public-repo-1.hortonworks.com/ambari/suse11/2.x/updates/2.0.1/ambari.repo"
-  default['ambari']['ubuntu_12_repo'] = "http://public-repo-1.hortonworks.com/ambari/ubuntu12/2.x/updates/2.0.1"
+when '1.7'
+  default['ambari']['rhel_5_repo'] = 'http://public-repo-1.hortonworks.com/ambari/centos5/1.x/updates/1.7.0/ambari.repo'
+  default['ambari']['rhel_6_repo'] = 'http://public-repo-1.hortonworks.com/ambari/centos6/1.x/updates/1.7.0/ambari.repo'
+  default['ambari']['suse_11_repo'] = 'http://public-repo-1.hortonworks.com/ambari/suse11/1.x/updates/1.7.0/ambari.repo'
+  default['ambari']['ubuntu_12_repo'] = 'http://public-repo-1.hortonworks.com/ambari/ubuntu12/1.x/updates/1.7.0'
+when '2.0', '2'
+  default['ambari']['rhel_5_repo'] = 'http://public-repo-1.hortonworks.com/ambari/centos5/2.x/updates/2.0.1/ambari.repo'
+  default['ambari']['rhel_6_repo'] = 'http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.0.1/ambari.repo'
+  default['ambari']['suse_11_repo'] = 'http://public-repo-1.hortonworks.com/ambari/suse11/2.x/updates/2.0.1/ambari.repo'
+  default['ambari']['ubuntu_12_repo'] = 'http://public-repo-1.hortonworks.com/ambari/ubuntu12/2.x/updates/2.0.1'
 end
 
-default['ambari']['admin_user'] = "admin"
-default['ambari']['admin_password'] = "admin"
+default['ambari']['admin_user'] = 'admin'
+default['ambari']['admin_password'] = 'admin'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,10 +5,10 @@ license          'Apache 2.0'
 description      'Installs/Configures ambari'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.0'
-supports 'redhat', ">= 5.0"
-supports 'centos', ">= 5.0"
-supports 'amazon', ">= 5.0"
-supports 'scientific', ">= 5.0"
-supports 'suse', ">= 11.0"
-supports 'ubuntu', ">= 12.0"
+supports 'redhat', '>= 5.0'
+supports 'centos', '>= 5.0'
+supports 'amazon', '>= 5.0'
+supports 'scientific', '>= 5.0'
+supports 'suse', '>= 11.0'
+supports 'ubuntu', '>= 12.0'
 depends 'apt'

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -17,53 +17,50 @@
 # limitations under the License.
 #
 
-include_recipe "ambari::setup_package_manager"
+include_recipe 'ambari::setup_package_manager'
 
-%w'ambari-agent'.each do | pack |
+%w(ambari-agent).each do |pack|
   package pack do
     action :install
   end
 end
 
-directory "/etc/ambari-agent/conf.chef" do
-  owner "root"
-  group "root"
-  mode "0755"
+directory '/etc/ambari-agent/conf.chef' do
+  owner 'root'
+  group 'root'
+  mode '0755'
   action :create
 end
 
-execute "move existing ambari configuration" do
-  command "mv /etc/ambari-agent/conf /etc/ambari-agent/conf.dist"
+execute 'move existing ambari configuration' do
+  command 'mv /etc/ambari-agent/conf /etc/ambari-agent/conf.dist'
   only_if do
-    not ::File.exists?("/etc/ambari-agent/conf.dist")
+    !::File.exist?('/etc/ambari-agent/conf.dist')
   end
 end
 
-execute "alternatives configured confdir" do
-  command "update-alternatives --install /etc/ambari-agent/conf ambari-agent-conf /etc/ambari-agent/conf.chef 90"
+execute 'alternatives configured confdir' do
+  command 'update-alternatives --install /etc/ambari-agent/conf ambari-agent-conf /etc/ambari-agent/conf.chef 90'
 end
 
 if Chef::Config[:solo]
-  Chef::Log.warn("This recipe uses search. Chef Solo does not support search.")
+  Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
 else
-  ambari_server_fqdn = node['ambari']['server_fqdn'] || search('node', 'run_list:recipe\[ambari\:\:server\] AND chef_environment:'+node.chef_environment).first['fqdn']
+  ambari_server_fqdn = node['ambari']['server_fqdn'] || search('node', 'run_list:recipe\[ambari\:\:server\] AND chef_environment:' + node.chef_environment).first['fqdn']
 end
 
-template "/etc/ambari-agent/conf/ambari-agent.ini" do
-  source "ambari-agent.ini.erb"
+template '/etc/ambari-agent/conf/ambari-agent.ini' do
+  source 'ambari-agent.ini.erb'
   mode 0755
-  user "root"
-  group "root"
-  variables({
-    ambari_server_fqdn: ambari_server_fqdn
-  })
+  user 'root'
+  group 'root'
+  variables(ambari_server_fqdn: ambari_server_fqdn)
 end
 
-service "ambari-agent" do
-  action [ :enable, :start ]
+service 'ambari-agent' do
+  action [:enable, :start]
 end
 
-service "iptables" do
-  action [ :disable, :stop ]
+service 'iptables' do
+  action [:disable, :stop]
 end
-

--- a/recipes/blueprints.rb
+++ b/recipes/blueprints.rb
@@ -17,19 +17,17 @@
 # limitations under the License.
 #
 
-
 if Chef::Config[:solo]
-  Chef::Log.warn("This recipe uses search. Chef Solo does not support search.")
+  Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
 else
-  ambari_server_fqdn = node['ambari']['server_fqdn'] || search('node', 'run_list:recipe\[ambari\:\:server\] AND chef_environment:'+node.chef_environment).first['fqdn']
+  ambari_server_fqdn = node['ambari']['server_fqdn'] || search('node', 'run_list:recipe\[ambari\:\:server\] AND chef_environment:' + node.chef_environment).first['fqdn']
 end
 basic_auth_parameters = "--user #{node['ambari']['admin_user']}:#{node['ambari']['admin_password']}"
 
-execute "Init Blueprints" do
+execute 'Init Blueprints' do
   command "curl #{basic_auth_parameters} -H 'X-Requested-By:ambari-cookbook' --data '#{node['ambari']['blueprints']['blueprint_json'].to_json}' #{ambari_server_fqdn}:8080/api/v1/blueprints/#{node['ambari']['blueprints']['blueprint_name']}"
 end
 
-execute "Init Cluster" do
+execute 'Init Cluster' do
   command "curl #{basic_auth_parameters} -H 'X-Requested-By:ambari-cookbook' --data '#{node['ambari']['blueprints']['cluster_json'].to_json}' #{ambari_server_fqdn}:8080/api/v1/clusters/#{node['ambari']['blueprints']['cluster_name']}"
 end
-

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -17,21 +17,21 @@
 # limitations under the License.
 #
 
-include_recipe "ambari::setup_package_manager"
+include_recipe 'ambari::setup_package_manager'
 
-%w'ambari-server postgresql'.each do | pack |
-  package pack 
+%w(ambari-server postgresql).each do |pack|
+  package pack
 end
 
-execute "setup ambari-server" do
-  command "ambari-server setup -s"
+execute 'setup ambari-server' do
+  command 'ambari-server setup -s'
 end
 
-service "postgresql" do
-  action [ :enable, :start ]
+service 'postgresql' do
+  action [:enable, :start]
 end
 
-service "ambari-server" do
+service 'ambari-server' do
   status_command "/etc/init.d/ambari-server status | grep 'Ambari Server running'"
-  action [ :enable, :start ]
+  action [:enable, :start]
 end

--- a/recipes/setup_package_manager.rb
+++ b/recipes/setup_package_manager.rb
@@ -16,39 +16,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_recipe "apt"
+include_recipe 'apt'
 
-%w'wget'.each do | pack |
+%w(wget).each do |pack|
   package pack do
     action :install
   end
 end
 
-%w'openssl'.each do | pack |
+%w(openssl).each do |pack|
   package pack do
     action :upgrade
   end
 end
 
-
 case node['platform']
-when "redhat","centos","amazon","scientific"
+when 'redhat', 'centos', 'amazon', 'scientific'
   case node['platform_version'].to_i
   when 5
     yum_repo = node['ambari']['rhel_5_repo']
   when 6
     yum_repo = node['ambari']['rhel_6_repo']
   end
-  remote_file "/etc/yum.repos.d/ambari.repo" do
+  remote_file '/etc/yum.repos.d/ambari.repo' do
     source yum_repo
-    not_if { ::File.exists?("/etc/yum.repos.d/ambari.repo") }
+    not_if { ::File.exist?('/etc/yum.repos.d/ambari.repo') }
   end
-when "suse"
-  remote_file "/etc/zypp/repos.d/ambari.repo" do
+when 'suse'
+  remote_file '/etc/zypp/repos.d/ambari.repo' do
     source node['ambari']['suse_11_repo']
-    not_if { ::File.exists?("/etc/zypp/repos.d/ambari.repo") }
+    not_if { ::File.exist?('/etc/zypp/repos.d/ambari.repo') }
   end
-when "ubuntu"
+when 'ubuntu'
   apt_repository 'Ambari' do
     uri node['ambari']['ubuntu_12_repo']
     distribution 'Ambari'


### PR DESCRIPTION
This copies the testing framework from [caskdata/hadoop_cookbook](https://github.com/caskdata/hadoop_cookbook) to do syntax checking using `foodcritic` and `rubocop` and functionality testing using ChefSpec. There are no ChefSpec tests included in this pull request. Expect them in a subsequent PR. Other than the new files, there are no functionality changes, only syntax changes. Also, this includes a configuration to run these tests via Travis CI. You can add this repository and get free Continuous Integration testing! :yum: 