### PR TITLE
Allow chef-solo for agent recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Include `ambari::server` in your node's `run_list`:
 
 Include `ambari::agent` in your node's `run_list` (all the nodes of your cluster):
 
-The Ambari Server will be automatically detected, but you can override this detection using the attribute `node['ambari']['server']['fdqn']`.
+The Ambari Server will be automatically detected, but you can override this detection using the attribute `node['ambari']['server_fqdn']`.
 
 ```json
 {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@
 # Attributes:: default
 #
 
-default['ambari']['server_fqdn'] = 'localhost'
+# default['ambari']['server_fqdn'] = 'localhost'
 
 # Set default version to Ambari 2.0
 default['ambari']['version'] = '2.0'

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -43,11 +43,33 @@ execute 'alternatives configured confdir' do
   command 'update-alternatives --install /etc/ambari-agent/conf ambari-agent-conf /etc/ambari-agent/conf.chef 90'
 end
 
-if Chef::Config[:solo]
-  Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
-else
-  ambari_server_fqdn = node['ambari']['server_fqdn'] || search('node', 'run_list:recipe\[ambari\:\:server\] AND chef_environment:' + node.chef_environment).first['fqdn']
-end
+# Get Ambari Server FQDN
+#
+# Logic:
+# - is server set?
+# - am I server?
+# - must search
+#   - can I search?
+#   - search
+ambari_server_fqdn =
+  if node['ambari'].key?('server_fqdn') # Server is set
+    node['ambari']['server_fqdn']
+  elsif node['recipes'].include?('ambari::server') # Server is me
+    node['fqdn']
+  else # must search
+    if Chef::Config[:solo] # chef-solo can't search, by default
+      if node['recipes'].include?('chef-solo-search::default')
+        do_search = true # it can with chef-solo-search
+      else
+        do_search = false
+      end
+    else
+      do_search = true
+    end
+    if do_search == true
+      search('node', 'recipes:ambari\:\:server AND chef_environment:' + node.chef_environment).first['fqdn']
+    end
+  end
 
 template '/etc/ambari-agent/conf/ambari-agent.ini' do
   source 'ambari-agent.ini.erb'


### PR DESCRIPTION
The `ambari::agent` recipe should allow the user to specify the
Ambari server and the recipe should respect this setting. In the
case of Chef Solo, there could also be the `chef-solo-search`
cookbook in the run_list, which will give Chef Solo searching
capabilities.

Also, updated search to use recipes over run_list, so it picks up
use of `ambari::server` via a wrapper cookbook or role.