### PR TITLE
Copy logic from agent recipe for finding Ambari server

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ Documentation:
   Enabled: False
 HashSyntax:
   Enabled: False
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 AsciiComments:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,14 @@ gem 'foodcritic', '~> 3.0'
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
-gem 'chef', '< 12.0' if RUBY_VERSION.to_f < 2.0
+if RUBY_VERSION.to_f < 2.0
+  gem 'chef', '< 12.0'
+  gem 'varia_model', '< 0.5.0'
+else
+  gem 'chef'
+end
+
+gem 'chef-zero', '< 4.6' if RUBY_VERSION.to_f < 2.1
 
 gem 'rubocop'
 gem 'rubocop-checkstyle_formatter', require: false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,6 +46,5 @@ when '2.2.1'
   node.default['ambari']['debian_7_repo'] = 'http://public-repo-1.hortonworks.com/ambari/debian7/2.x/updates/2.2.1.1/ambari.list'
 end
 
-
 node.default['ambari']['admin_user'] = 'admin'
 node.default['ambari']['admin_password'] = 'admin'

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -57,15 +57,15 @@ ambari_server_fqdn =
   elsif node['recipes'].include?('ambari::server') # Server is me
     node['fqdn']
   else # must search
-    if Chef::Config[:solo] # chef-solo can't search, by default
-      if node['recipes'].include?('chef-solo-search::default')
-        do_search = true # it can with chef-solo-search
-      else
-        do_search = false
-      end
-    else
-      do_search = true
-    end
+    do_search = if Chef::Config[:solo] # chef-solo can't search, by default
+                  if node['recipes'].include?('chef-solo-search::default')
+                    true # it can with chef-solo-search
+                  else
+                    false
+                  end
+                else
+                  true
+                end
     if do_search == true
       search('node', 'recipes:ambari\:\:server AND chef_environment:' + node.chef_environment).first['fqdn']
     end

--- a/recipes/blueprints.rb
+++ b/recipes/blueprints.rb
@@ -17,11 +17,34 @@
 # limitations under the License.
 #
 
-if Chef::Config[:solo]
-  Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
-else
-  ambari_server_fqdn = node['ambari']['server_fqdn'] || search('node', 'run_list:recipe\[ambari\:\:server\] AND chef_environment:' + node.chef_environment).first['fqdn']
-end
+# Get Ambari Server FQDN
+#
+# Logic:
+# - is server set?
+# - am I server?
+# - must search
+#   - can I search?
+#   - search
+ambari_server_fqdn =
+  if node['ambari'].key?('server_fqdn') # Server is set
+    node['ambari']['server_fqdn']
+  elsif node['recipes'].include?('ambari::server') # Server is me
+    node['fqdn']
+  else # must search
+    if Chef::Config[:solo] # chef-solo can't search, by default
+      if node['recipes'].include?('chef-solo-search::default')
+        do_search = true # it can with chef-solo-search
+      else
+        do_search = false
+      end
+    else
+      do_search = true
+    end
+    if do_search == true
+      search('node', 'recipes:ambari\:\:server AND chef_environment:' + node.chef_environment).first['fqdn']
+    end
+  end
+
 basic_auth_parameters = "--user #{node['ambari']['admin_user']}:#{node['ambari']['admin_password']}"
 
 execute 'Init Blueprints' do

--- a/recipes/blueprints.rb
+++ b/recipes/blueprints.rb
@@ -31,15 +31,15 @@ ambari_server_fqdn =
   elsif node['recipes'].include?('ambari::server') # Server is me
     node['fqdn']
   else # must search
-    if Chef::Config[:solo] # chef-solo can't search, by default
-      if node['recipes'].include?('chef-solo-search::default')
-        do_search = true # it can with chef-solo-search
-      else
-        do_search = false
-      end
-    else
-      do_search = true
-    end
+    do_search = if Chef::Config[:solo] # chef-solo can't search, by default
+                  if node['recipes'].include?('chef-solo-search::default')
+                    true # it can with chef-solo-search
+                  else
+                    false
+                  end
+                else
+                  true
+                end
     if do_search == true
       search('node', 'recipes:ambari\:\:server AND chef_environment:' + node.chef_environment).first['fqdn']
     end


### PR DESCRIPTION
This copies the same logic from the `agent` recipe to `blueprints`... in the future, I'll refactor this into a library and DRY up the code. This replaces #21 with common code.