### PR TITLE
Use status_command to make service idempotent

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -76,6 +76,7 @@ else
 end
 
 service 'ambari-server' do
+  status_command 'service ambari-server status'
   supports :status => true, :restart => true, :reload => false
   action [:start, :enable]
 end


### PR DESCRIPTION
Otherwise, Chef will use its default method of determining if the service is running, which is to check the process list. This will cause Chef to attempt to start a started service, and under Ubuntu, that returns a non-zero exit status. Adding a `status_command` tells Chef how to check the status, since the Ambari Server process is a Java process and doesn't have `ambari-server` anywhere in its process output.