### PR TITLE
Ambari Agent can't start in Centos7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+.kitchen.yml
 
 .chef
+chefignore

--- a/templates/default/ambari-agent.ini.erb
+++ b/templates/default/ambari-agent.ini.erb
@@ -13,40 +13,50 @@
 # See the License for the specific
 
 [server]
-hostname = <%= @ambari_server_fqdn %>
-url_port = 8440
-secured_url_port = 8441
+hostname=<%= @ambari_server_fqdn %>
+url_port=8440
+secured_url_port=8441
 
 [agent]
-prefix = /var/lib/ambari-agent/data
-loglevel = INFO
-data_cleanup_interval = 86400
-data_cleanup_max_age = 2592000
-data_cleanup_max_size_mb = 100
-ping_port = 8670
-cache_dir = /var/lib/ambari-agent/cache
-tolerate_download_failures = true
-run_as_user = root
-parallel_execution = 0
-alert_grace_period = 5
-tmp_dir = /var/lib/ambari-agent/data/tmp
+logdir=/var/log/ambari-agent
+piddir=/var/run/ambari-agent
+prefix=/var/lib/ambari-agent/data
+;loglevel=(DEBUG/INFO)
+loglevel=INFO
+data_cleanup_interval=86400
+data_cleanup_max_age=2592000
+data_cleanup_max_size_MB = 100
+ping_port=8670
+cache_dir=/var/lib/ambari-agent/cache
+tolerate_download_failures=true
+run_as_user=root
+parallel_execution=0
+alert_grace_period=5
+alert_kinit_timeout=14400000
+system_resource_overrides=/etc/resource_overrides
+; memory_threshold_soft_mb=400
+; memory_threshold_hard_mb=1000
 
 [security]
-keysdir = /var/lib/ambari-agent/keys
-server_crt = ca.crt
-passphrase_env_var_name = AMBARI_PASSPHRASE
+keysdir=/var/lib/ambari-agent/keys
+server_crt=ca.crt
+passphrase_env_var_name=AMBARI_PASSPHRASE
+ssl_verify_cert=0
+
 
 [services]
-pidlookuppath = /var/run/
+pidLookupPath=/var/run/
 
 [heartbeat]
-state_interval = 6
-dirs = /etc/hadoop,/etc/hadoop/conf,/etc/hbase,/etc/hcatalog,/etc/hive,/etc/oozie,
-        /etc/sqoop,/etc/ganglia,
-        /var/run/hadoop,/var/run/zookeeper,/var/run/hbase,/var/run/templeton,/var/run/oozie,
-        /var/log/hadoop,/var/log/zookeeper,/var/log/hbase,/var/run/templeton,/var/log/hive
-log_lines_count = 300
+state_interval_seconds=60
+dirs=/etc/hadoop,/etc/hadoop/conf,/etc/hbase,/etc/hcatalog,/etc/hive,/etc/oozie,
+  /etc/sqoop,/etc/ganglia,
+  /var/run/hadoop,/var/run/zookeeper,/var/run/hbase,/var/run/templeton,/var/run/oozie,
+  /var/log/hadoop,/var/log/zookeeper,/var/log/hbase,/var/run/templeton,/var/log/hive
+; 0 - unlimited
+log_lines_count=300
+idle_interval_min=1
+idle_interval_max=10
 
 [logging]
 syslog_enabled = 0
-


### PR DESCRIPTION
Hello all!

As explained in [this issue](https://github.com/jp/ambari/issues/34), using the ambari-agent.ini template as provided in the cookbook can lead to an unusable system, since during the chef-client it will try to chown almost all filesystem directories and files to root:root, breaking everything and making it almost impossible to recover if you don't have a snapshot to roll back.

I don't know how to write any test to this rather than just try to install on Centos7.
