### PR TITLE
set log directory and PID directory AMBARI-18525

### DIFF
--- a/templates/default/ambari-agent.ini.erb
+++ b/templates/default/ambari-agent.ini.erb
@@ -30,6 +30,8 @@ run_as_user = root
 parallel_execution = 0
 alert_grace_period = 5
 tmp_dir = /var/lib/ambari-agent/data/tmp
+logdir=/var/log/ambari-agent
+piddir=/var/run/ambari-agent
 
 [security]
 keysdir = /var/lib/ambari-agent/keys


### PR DESCRIPTION
Hopefully this won't break the Ambari agent in previous versions but in Ambari 2.4 if these two config values are not present, the Ambari agent breaks /home permissions and sudo on the machine as described in this bug ticket https://issues.apache.org/jira/browse/AMBARI-18525

