### PR TITLE
Refactor the MySQL DB code and add JDBC

### DIFF
--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -12,7 +12,30 @@ describe 'ambari::server' do
       expect(chef_run).to install_package('ambari-server')
     end
   end
+
+  context 'using MySQL' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
+        node.override['ambari']['database']['type'] = 'mysql'
+        stub_command(/update-alternatives --display /).and_return(false)
+      end.converge(described_recipe)
+    end
+
+    it 'installs mysql-connector-java package' do
+      expect(chef_run).to install_package('mysql-connector-java')
+    end
+  end
+
+  context 'on Ubuntu using MySQL' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04) do |node|
+        node.override['ambari']['database']['type'] = 'mysql'
+        stub_command(/update-alternatives --display /).and_return(false)
+      end.converge(described_recipe)
+    end
+
+    it 'installs libmysql-java package' do
+      expect(chef_run).to install_package('libmysql-java')
+    end
+  end
 end
-#  execute[setup ambari-server]       ambari/recipes/server.rb:66
-#  service[postgresql]                ambari/recipes/server.rb:72
-#  service[ambari-server]             ambari/recipes/server.rb:82


### PR DESCRIPTION
This moves everything for MySQL under the single case statement. The biggest difference is the use of concatenation to assemble `db_opts` and also the inclusion of the JDBC driver. This makes it easier to reuse this database service for other things, such as Ranger, Oozie, or Hive.